### PR TITLE
PHP Composer Install use wget to consider configured Proxy

### DIFF
--- a/images/linux/scripts/installers/php.sh
+++ b/images/linux/scripts/installers/php.sh
@@ -238,7 +238,7 @@ apt-get remove --purge -yq php7.2-dev
 apt-fast install -y --no-install-recommends snmp
 
 # Install composer
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+wget -O composer-setup.php https://getcomposer.org/installer
 php -r "if (hash_file('SHA384', 'composer-setup.php') === '48e3236262b34d30969dca3c37281b3b4bbe3221bda826ac6a9a62d6444cdb0dcd0615698a5cbe587c3f0fe57a54d8f5') { echo 'Installer for Composer verified is verified.'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
 sudo mv composer.phar /usr/bin/composer


### PR DESCRIPTION
Instead of using php script, wget considers a configured Proxy for accessing the internet (HTTP_PROXY environment)